### PR TITLE
Remove Python code encoding hints

### DIFF
--- a/pelican/plugins/seo/seo.py
+++ b/pelican/plugins/seo/seo.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 SEO is a Pelican plugin to helps you improve your Pelican site SEO to
 reach the tops positions on search engines like Qwant, DuckDuckGo or Google.


### PR DESCRIPTION
Hinting at python file encoding is optional in Python 3.