### PR TITLE
Force real-path normalization to allow for relative resolution

### DIFF
--- a/pelican/plugins/seo/seo_enhancer/html_enhancer/breadcrumb_schema_creator.py
+++ b/pelican/plugins/seo/seo_enhancer/html_enhancer/breadcrumb_schema_creator.py
@@ -5,7 +5,7 @@ https://schema.org/BreadcrumbList : JSON-LD format.
 """
 
 import os
-from pathlib import PurePath
+from pathlib import Path
 
 
 class BreadcrumbSchemaCreator:
@@ -26,8 +26,8 @@ class BreadcrumbSchemaCreator:
         and get the file path by discarding output path.
         By default, output path is 'output/' but it can be changed in Pelican settings.
         """
-        path = PurePath(self._path)
-        output_path = PurePath(self._output_path)
+        path = Path(self._path).resolve()
+        output_path = Path(self._output_path).resolve()
 
         file_path = path.relative_to(output_path)
 


### PR DESCRIPTION
Forces real-path normalization to compute the relative path.

Fix these kind of errors I encountered on my setup:

    (...)
    -> Writing /Users/kde/blog/output/2020/10/billing-pipeline-critical-time-sensitive-system/index.html
    CRITICAL: '/Users/kde/blog/output/2020/10/billing-pipeline-critical-time-sensitive-system/index.html' does not start with 'output'
