### PR TITLE
Fix definitively encoding issues when open file

### DIFF
--- a/pelican/plugins/seo/seo_enhancer/__init__.py
+++ b/pelican/plugins/seo/seo_enhancer/__init__.py
@@ -74,7 +74,7 @@ class SEOEnhancer:
         Open HTML file, add HTML enhancements with bs4 and create the new HTML files.
         """
 
-        with open(path) as html_file:
+        with open(path, "r", encoding="utf8") as html_file:
             html_content = html_file.read()
             soup = BeautifulSoup(html_content, features="html.parser")
 
@@ -91,7 +91,7 @@ class SEOEnhancer:
             schema_script.append(json.dumps(enhancements[schema], ensure_ascii=False))
             soup.head.append(schema_script)
 
-        with open(path, "w") as html_file:
+        with open(path, "w", encoding="utf8") as html_file:
             html_file.write(soup.prettify())
 
         logger.info(f"SEO plugin - SEO Enhancement: Done for {path}")

--- a/pelican/plugins/seo/seo_report/__init__.py
+++ b/pelican/plugins/seo/seo_report/__init__.py
@@ -267,7 +267,7 @@ class SEOReport:
         )
 
         # Create HTML file
-        with open("seo_report.html", "w") as report:
+        with open("seo_report.html", "w", encoding="utf8") as report:
             report.write(output)
 
         logger.info("SEO plugin - SEO Report: seo_report.html file created")

--- a/pelican/plugins/seo/tests/test_seo_report.py
+++ b/pelican/plugins/seo/tests/test_seo_report.py
@@ -67,7 +67,7 @@ class TestSEOReport:
 
             # mocked_open and the file handle got all
             # executed calls, and can assert them
-            mocked_open.assert_called_once_with("seo_report.html", "w")
+            mocked_open.assert_called_once_with("seo_report.html", "w", encoding="utf8")
             mocked_file_handle.write.assert_called_once()
 
             # Get all arguments in the mocked write call and select the first


### PR DESCRIPTION
Should definitively fix #9 by forcing utf-8 encoding every time we open a Pelican file.