### PR TITLE
Fix evaluation of link-less anchor tags

### DIFF
--- a/pelican/plugins/seo/seo_report/seo_analyzer/internal_link_analyzer.py
+++ b/pelican/plugins/seo/seo_report/seo_analyzer/internal_link_analyzer.py
@@ -8,7 +8,7 @@ class InternalLinkAnalyzer:
 
     def __init__(self, content, siteurl):
         self._soup = BeautifulSoup(content, features="html.parser")
-        self._links = self._soup.find_all("a")
+        self._links = self._soup.find_all("a", href=True)
         self._siteurl = siteurl
 
     def has_internal_link(self):

--- a/pelican/plugins/seo/tests/conftest.py
+++ b/pelican/plugins/seo/tests/conftest.py
@@ -170,6 +170,7 @@ def fake_article_multiple_elements():
                         <a href='https://www.fakesite.com'>Fake internal link</a>
                         <a href='https://www.test.com'>Fake external link</a>
                         <a href='www.fakesite.com/test/'>Fake internal path link</a>
+                        <a>a tag without href attribute</a>
                     </body>
                 </html>"""
 


### PR DESCRIPTION
When the SEO plugin encounter this kind of tags:

```html
<a name="L-1"></a>
```

It fails with that traceback:

```pythontb
CRITICAL: 'href'
Traceback (most recent call last):
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/bin/pelican", line 8, in <module>
    sys.exit(main())
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/__init__.py", line 512, in main
    pelican.run()
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/__init__.py", line 115, in run
    signals.all_generators_finalized.send(generators)
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/blinker/base.py", line 266, in send
    return [(receiver, receiver(sender, **kwargs))
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/blinker/base.py", line 266, in <listcomp>
    return [(receiver, receiver(sender, **kwargs))
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo.py", line 64, in run_seo_report
    seo_report.generate(site_name=site_name, documents_analysis=documents_analysis)
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo_report/__init__.py", line 242, in generate
    document_report = self._launch_report(document_analysis)
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo_report/__init__.py", line 220, in _launch_report
    internal_link_report = self._internal_link_report(
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo_report/__init__.py", line 182, in _internal_link_report
    internal_link_occurrence = internal_link_analysis.internal_link_occurrence
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo_report/seo_analyzer/internal_link_analyzer.py", line 33, in internal_link_occurrence
    return len([link for link in self._links if self._siteurl in link["href"]])
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/pelican/plugins/seo/seo_report/seo_analyzer/internal_link_analyzer.py", line 33, in <listcomp>
    return len([link for link in self._links if self._siteurl in link["href"]])
  File "/Users/kde/Library/Caches/pypoetry/virtualenvs/blog-Nb0Mdndq-py3.8/lib/python3.8/site-packages/bs4/element.py", line 1406, in __getitem__
    return self.attrs[key]
KeyError: 'href'
```

This PR fix this issue.